### PR TITLE
Document rendering backend lifetimes

### DIFF
--- a/src/render.go
+++ b/src/render.go
@@ -1,3 +1,10 @@
+// Rendering interface and embedded shader sources.
+//
+// This file defines backend-agnostic abstractions that every renderer
+// must implement. Calls are expected to occur on the main rendering
+// thread and assume a valid GPU context. [PITFALL] Context loss or
+// incompatible GPU drivers will invalidate resources and may crash
+// rendering.
 package main
 
 import (
@@ -70,10 +77,25 @@ type Renderer interface {
 	SetModelVertexData(bufferIndex uint32, values []byte)
 	SetModelIndexData(bufferIndex uint32, values ...uint32)
 
+	// RenderQuad draws a screen-aligned quad using the current
+	// pipeline state. Not safe for concurrent use; keep state changes
+	// minimal for best performance.
 	RenderQuad()
+	// RenderElements issues an indexed draw call.
+	// mode selects primitive topology, count is element count, and
+	// offset is the starting byte within the index buffer. Not
+	// goroutine-safe.
 	RenderElements(mode PrimitiveMode, count, offset int)
+	// RenderCubeMap converts an environment texture into a cube map.
+	// Must be invoked on the render thread and may perform multiple
+	// draw calls internally.
 	RenderCubeMap(envTexture Texture, cubeTexture Texture)
+	// RenderFilteredCubeMap prefilters a cube map for image-based
+	// lighting. High sample counts improve quality at the cost of
+	// CPU/GPU time.
 	RenderFilteredCubeMap(distribution int32, cubeTexture Texture, filteredTexture Texture, mipmapLevel, sampleCount int32, roughness float32)
+	// RenderLUT generates a lookup table texture for BRDF
+	// integration. Expensive; run during initialization.
 	RenderLUT(distribution int32, cubeTexture Texture, lutTexture Texture, sampleCount int32)
 }
 

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -3,6 +3,12 @@
 // IF YOU MAKE CHANGES TO THIS FILE, YOU MUST ALSO MAKE
 // EQUIVALENT CHANGES TO render_gl_gl32.go
 
+// OpenGL 2.1 renderer implementation.
+//
+// Provides texture, shader, and buffer management using the go-gl
+// bindings and requires a driver supporting OpenGL 2.1. [PITFALL]
+// Losing the GL context or running on an incompatible GPU driver will
+// invalidate resources and may crash rendering operations.
 package main
 
 import (
@@ -24,8 +30,9 @@ import (
 //const GL_SHADER_VER = 120 // OpenGL 2.1
 
 // ------------------------------------------------------------------
-// ShaderProgram_GL21
-
+// ShaderProgram_GL21 wraps an OpenGL program object.
+// Lifetime: valid until deleted or context loss; methods are not
+// goroutine-safe.
 type ShaderProgram_GL21 struct {
 	// Program
 	program uint32
@@ -152,8 +159,9 @@ func (r *Renderer_GL21) linkProgram(params ...uint32) (program uint32, err error
 }
 
 // ------------------------------------------------------------------
-// Texture_GL21
-
+// Texture_GL21 represents an OpenGL texture handle.
+// Lifetime: freed by a finalizer on the main thread; invalid after
+// context loss. Not concurrency-safe.
 type Texture_GL21 struct {
 	width  int32
 	height int32
@@ -307,6 +315,10 @@ func (t *Texture_GL21) MapInternalFormat(i int32) uint32 {
 // ------------------------------------------------------------------
 // Renderer_GL21
 
+// Renderer_GL21 manages OpenGL state and buffer objects for the 2.1
+// backend. Buffer handles live for the lifetime of the renderer and are
+// released during Close; none of the fields are safe for concurrent
+// access.
 type Renderer_GL21 struct {
 	fbo         uint32
 	fbo_texture uint32
@@ -1453,13 +1465,23 @@ func (r *Renderer_GL21) SetModelIndexData(bufferIndex uint32, values ...uint32) 
 	gl.BufferData(gl.ELEMENT_ARRAY_BUFFER, len(values)*4, unsafe.Pointer(&data.Bytes()[0]), gl.STATIC_DRAW)
 }
 
+// RenderQuad draws the currently bound quad.
+// Thread-safety: must be called on the render thread.
+// Performance: minimal when state is preconfigured.
 func (r *Renderer_GL21) RenderQuad() {
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 }
+
+// RenderElements submits an indexed draw call.
+// mode selects primitive topology, count is index count and offset is
+// the starting byte within the index buffer. Not goroutine-safe.
 func (r *Renderer_GL21) RenderElements(mode PrimitiveMode, count, offset int) {
 	gl.DrawElementsWithOffset(r.MapPrimitiveMode(mode), int32(count), gl.UNSIGNED_INT, uintptr(offset))
 }
 
+// RenderCubeMap renders a panorama texture into a cube map target.
+// envTex is the equirectangular source and cubeTex the destination
+// cube map. Expensive and intended for initialization only.
 func (r *Renderer_GL21) RenderCubeMap(envTex Texture, cubeTex Texture) {
 	envTexture := envTex.(*Texture_GL21)
 	cubeTexture := cubeTex.(*Texture_GL21)
@@ -1490,6 +1512,12 @@ func (r *Renderer_GL21) RenderCubeMap(envTex Texture, cubeTex Texture) {
 	gl.BindTexture(gl.TEXTURE_CUBE_MAP, cubeTexture.handle)
 	gl.GenerateMipmap(gl.TEXTURE_CUBE_MAP)
 }
+
+// RenderFilteredCubeMap prefilters a cube map for image-based lighting.
+// distribution selects the BRDF, cubeTex is the input environment
+// map, filteredTex the output, mipmapLevel and sampleCount trade
+// quality for time, and roughness controls reflection blur.
+// Thread-safety: render thread only.
 func (r *Renderer_GL21) RenderFilteredCubeMap(distribution int32, cubeTex Texture, filteredTex Texture, mipmapLevel, sampleCount int32, roughness float32) {
 	cubeTexture := cubeTex.(*Texture_GL21)
 	filteredTexture := filteredTex.(*Texture_GL21)
@@ -1531,6 +1559,9 @@ func (r *Renderer_GL21) RenderFilteredCubeMap(distribution int32, cubeTex Textur
 	}
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }
+
+// RenderLUT generates a BRDF lookup texture. sampleCount determines
+// quality versus generation time. Invoke sparingly on the render thread.
 func (r *Renderer_GL21) RenderLUT(distribution int32, cubeTex Texture, lutTex Texture, sampleCount int32) {
 	cubeTexture := cubeTex.(*Texture_GL21)
 	lutTexture := lutTex.(*Texture_GL21)

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -3,7 +3,10 @@
 // This is almost identical to render_gl.go except it uses a VAO
 // for GL 3.2 which is the minimum version that runs on modern
 // macOS (Intel and ARM). Work adapted from assemblaj/fantasma
-
+//
+// OpenGL 3.2 renderer using core profile and VAOs. Requires a driver
+// supporting OpenGL 3.2. [PITFALL] Loss of context or incompatible GPU
+// drivers will invalidate resources and may crash rendering.
 package main
 
 import (
@@ -24,8 +27,8 @@ import (
 //const GL_SHADER_VER = 150 // OpenGL 3.2
 
 // ------------------------------------------------------------------
-// ShaderProgram_GL32
-
+// ShaderProgram_GL32 wraps an OpenGL program object.
+// Lifetime: valid until deletion or context loss. Not goroutine-safe.
 type ShaderProgram_GL32 struct {
 	// Program
 	program uint32
@@ -151,8 +154,9 @@ func (r *Renderer_GL32) linkProgram(params ...uint32) (program uint32, err error
 }
 
 // ------------------------------------------------------------------
-// Texture_GL32
-
+// Texture_GL32 represents an OpenGL texture handle.
+// Lifetime: freed via a finalizer; invalid after context loss. Not
+// safe for concurrent use.
 type Texture_GL32 struct {
 	width  int32
 	height int32
@@ -304,8 +308,9 @@ func (t *Texture_GL32) MapInternalFormat(i int32) uint32 {
 }
 
 // ------------------------------------------------------------------
-// Renderer_GL32
-
+// Renderer_GL32 owns OpenGL 3.2 state and buffer objects. Buffers are
+// freed when Close is called and should only be accessed on the render
+// thread.
 type Renderer_GL32 struct {
 	fbo         uint32
 	fbo_texture uint32
@@ -1460,13 +1465,21 @@ func (r *Renderer_GL32) SetModelIndexData(bufferIndex uint32, values ...uint32) 
 	gl.BufferData(gl.ELEMENT_ARRAY_BUFFER, len(values)*4, unsafe.Pointer(&data.Bytes()[0]), gl.STATIC_DRAW)
 }
 
+// RenderQuad draws the currently bound quad. Must be called from the
+// render thread.
 func (r *Renderer_GL32) RenderQuad() {
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 }
+
+// RenderElements submits an indexed draw call. mode selects primitive
+// topology, count is index count and offset is the starting byte within
+// the index buffer. Not goroutine-safe.
 func (r *Renderer_GL32) RenderElements(mode PrimitiveMode, count, offset int) {
 	gl.DrawElementsWithOffset(r.MapPrimitiveMode(mode), int32(count), gl.UNSIGNED_INT, uintptr(offset))
 }
 
+// RenderCubeMap renders a panorama texture into a cube map target.
+// Heavy operation intended for initialization only.
 func (r *Renderer_GL32) RenderCubeMap(envTex Texture, cubeTex Texture) {
 	envTexture := envTex.(*Texture_GL32)
 	cubeTexture := cubeTex.(*Texture_GL32)
@@ -1497,6 +1510,12 @@ func (r *Renderer_GL32) RenderCubeMap(envTex Texture, cubeTex Texture) {
 	gl.BindTexture(gl.TEXTURE_CUBE_MAP, cubeTexture.handle)
 	gl.GenerateMipmap(gl.TEXTURE_CUBE_MAP)
 }
+
+// RenderFilteredCubeMap prefilters cube maps for image-based lighting.
+// distribution selects the BRDF; cubeTex is the input environment map;
+// filteredTex is the output; mipmapLevel and sampleCount control
+// quality versus time; roughness controls reflection blur.
+// Thread-safety: render thread only.
 func (r *Renderer_GL32) RenderFilteredCubeMap(distribution int32, cubeTex Texture, filteredTex Texture, mipmapLevel, sampleCount int32, roughness float32) {
 	cubeTexture := cubeTex.(*Texture_GL32)
 	filteredTexture := filteredTex.(*Texture_GL32)
@@ -1538,6 +1557,9 @@ func (r *Renderer_GL32) RenderFilteredCubeMap(distribution int32, cubeTex Textur
 	}
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }
+
+// RenderLUT generates a BRDF lookup table. sampleCount trades
+// precision for generation time. Invoke sparingly on the render thread.
 func (r *Renderer_GL32) RenderLUT(distribution int32, cubeTex Texture, lutTex Texture, sampleCount int32) {
 	cubeTexture := cubeTex.(*Texture_GL32)
 	lutTexture := lutTex.(*Texture_GL32)

--- a/src/render_kinc.go
+++ b/src/render_kinc.go
@@ -1,5 +1,10 @@
 //go:build kinc
 
+// Kinc rendering backend using CGO bindings.
+//
+// Requires the Kinc library and a compatible GPU driver. [PITFALL]
+// Context loss or driver incompatibilities will invalidate GPU
+// resources and may crash rendering.
 package main
 
 import (
@@ -56,8 +61,9 @@ var BlendFunctionLUT = map[BlendFunc]C.kinc_g4_blending_factor_t{
 }
 
 // ------------------------------------------------------------------
-// Texture
-
+// Texture encapsulates a Kinc texture handle.
+// Lifetime: freed via a finalizer; invalid after context loss. Not
+// goroutine-safe.
 type Texture struct {
 	width  int32
 	height int32
@@ -114,6 +120,9 @@ type PipelineParams struct {
 	dst BlendFunc
 }
 
+// Pipeline caches a compiled Kinc pipeline and its uniform/texture
+// locations. Lifetime: owned by the renderer; not safe for concurrent
+// use.
 type Pipeline struct {
 	kp *C.kinc_g4_pipeline_t
 	u  map[string]C.kinc_g4_constant_location_t
@@ -137,8 +146,9 @@ func (p *Pipeline) RegisterUniforms(names ...string) {
 }
 
 // ------------------------------------------------------------------
-// Renderer
-
+// Renderer orchestrates Kinc GPU state and buffers. Resources are
+// allocated in Init and released on Close; calls must occur on the
+// render thread.
 type Renderer struct {
 	layout       *C.kinc_g4_vertex_structure_t
 	indexBuffer  *C.kinc_g4_index_buffer_t
@@ -299,6 +309,8 @@ func (r *Renderer) SetVertexData(values ...float32) {
 	C.kinc_g4_vertex_buffer_unlock_all(r.vertexBuffer)
 }
 
+// RenderQuad draws the currently configured quad. Must be invoked on
+// the render thread and assumes buffers are pre-populated.
 func (r *Renderer) RenderQuad() {
 	C.kinc_g4_set_vertex_buffer(r.vertexBuffer)
 	C.kinc_g4_set_index_buffer(r.indexBuffer)


### PR DESCRIPTION
## Summary
- document rendering interfaces and add warnings about context loss
- annotate textures, shaders, and buffers with lifetime rules
- describe thread-safety and performance of draw calls

## Testing
- `go vet ./...` *(fails: Package gl was not found in the pkg-config search path)*
- `go build -o /tmp/game ./src` *(fails: Xcursor.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d0120740832f93ec17357bd2f2d7