### PR TITLE
docs: clarify Windows UTF-8 fix and zip wrapper

### DIFF
--- a/src/common.go
+++ b/src/common.go
@@ -1375,6 +1375,12 @@ func IsZipPath(path string) (isZip bool, zipFilePath string, pathInZip string) {
 	return false, "", ""
 }
 
+// zipMemFileReader wraps a bytes.Reader so that a file extracted from a zip
+// archive satisfies io.ReadSeekCloser. The entire entry is kept in memory and
+// the underlying archive is closed once reading begins.
+// [PITFALL] Cross-platform builds must ensure paths inside archives are
+// normalized with forward slashes or lookups may fail on some operating
+// systems.
 type zipMemFileReader struct {
 	reader     *bytes.Reader   // Reader for the in-memory content of the file in zip
 	zipArchive *zip.ReadCloser // The main zip archive reader
@@ -1394,7 +1400,9 @@ func (zmfr *zipMemFileReader) Close() error {
 }
 
 // OpenFile opens a regular file or a file within a zip archive.
-// For zip files, it reads the entire entry into memory to ensure full io.Seeker compatibility.
+// For zip files, it reads the entire entry into memory to ensure full
+// io.Seeker compatibility and returns a wrapper that closes the archive when
+// the caller is finished.
 // It returns an io.ReadSeekCloser that must be closed by the caller.
 func OpenFile(filename string) (io.ReadSeekCloser, error) {
 	filename = filepath.ToSlash(filename)

--- a/src/stdout_windows.go
+++ b/src/stdout_windows.go
@@ -1,6 +1,8 @@
 //go:build windows
 // +build windows
 
+// Windows UTF-8 output fix: attach to the parent console so stdout/stderr use
+// the correct encoding when running on Windows.
 package main
 
 import (


### PR DESCRIPTION
## Summary
- document Windows UTF-8 console attachment
- explain zip file wrapper and call out cross-platform pitfall

## Testing
- `go build -o /tmp/ikemen ./src` *(fails: Package gl not found; Xrandr.h missing; Package alsa not found; Package gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d01f78cc832facf2b1c7869f2233