### PR TITLE
Add commented M.U.G.E.N template files

### DIFF
--- a/data/example.cmd
+++ b/data/example.cmd
@@ -1,0 +1,30 @@
+; Command File Template for Ikemen GO
+; Each parameter references M.U.G.E.N documentation and notes compatibility.
+
+[Remap]
+; [MUGEN-Compat] Button remapping (M.U.G.E.N docs: CMD -> Remap)
+; Example: a = x
+
+[Defaults]
+command.time = 15 ; [MUGEN-Compat] Frames allowed to enter command
+buffer.time = 1 ; [Ikemen-Only] Input buffer frames
+
+; [EXAMPLE] Quarter circle forward punch
+[Command]
+name = "qcf_x" ; [MUGEN-Compat] Command name
+command = ~D, DF, F, x ; [MUGEN-Compat] Input sequence
+time = 20 ; [MUGEN-Compat] Frames to complete command
+
+; [EXAMPLE] 360 motion
+[Command]
+name = "spin" ; [MUGEN-Compat]
+command = ~F, DF, D, DB, B, UB, U, UF ; [MUGEN-Compat]
+time = 30 ; [MUGEN-Compat]
+
+[State -1]
+; Example of triggering a command
+[State -1, QCF]
+type = ChangeState ; [MUGEN-Compat]
+value = 3000 ; [MUGEN-Compat]
+triggerall = command = "qcf_x" ; [MUGEN-Compat]
+trigger1 = statetype = S ; [MUGEN-Compat]

--- a/data/example.cns
+++ b/data/example.cns
@@ -1,0 +1,29 @@
+; Constants File Template for Ikemen GO
+; Each parameter references M.U.G.E.N documentation and notes compatibility.
+
+[Data]
+life = 1000 ; [MUGEN-Compat] Starting life (M.U.G.E.N docs: CNS -> Data)
+attack = 100 ; [MUGEN-Compat] Base attack strength
+defence = 100 ; [MUGEN-Compat] Base defense power
+fall.defence_up = 50 ; [MUGEN-Compat] Defense increase while falling
+liedown.time = 60 ; [MUGEN-Compat] Time before getting up
+airjuggle = 15 ; [MUGEN-Compat] Juggle capacity
+sparkno = 2 ; [MUGEN-Compat] Default hit spark number
+guard.sparkno = 40 ; [MUGEN-Compat] Guard spark
+KO.echo = 0 ; [MUGEN-Compat] Play KO sound with echo
+volume = 0 ; [MUGEN-Compat] Volume correction
+IntPersistIndex = 0 ; [MUGEN-Compat] Integer persistence starting index
+FloatPersistIndex = 0 ; [MUGEN-Compat] Float persistence starting index
+parry.enabled = 1 ; [Ikemen-Only] Enable parry system
+
+[Velocity]
+walk.fwd = 2.5 ; [MUGEN-Compat] Walk forward speed
+walk.back = -2.5 ; [MUGEN-Compat] Walk backward speed
+run.fwd = 5 ; [MUGEN-Compat] Run forward speed
+run.back = -5 ; [MUGEN-Compat] Run backward speed
+
+[Movement]
+airjump.num = 1 ; [MUGEN-Compat] Number of air jumps
+airjump.height = 35 ; [MUGEN-Compat] Height added by air jump
+yaccel = 0.72 ; [MUGEN-Compat] Gravity applied to player
+air.gethit.groundrecover = 0 ; [Ikemen-Only] Allow quick ground recover from air hit

--- a/data/example.def
+++ b/data/example.def
@@ -1,0 +1,39 @@
+; Stage Definition Template for Ikemen GO
+; Each parameter references M.U.G.E.N documentation and notes compatibility.
+
+[Info]
+name = "Example Stage" ; [MUGEN-Compat] Internal stage name (M.U.G.E.N docs: stage info)
+displayname = "Example Stage" ; [MUGEN-Compat] Name shown in select screen
+version = "1.0" ; [MUGEN-Compat] Format version
+mugenversion = 1.1 ; [MUGEN-Compat] Required M.U.G.E.N version
+ikemenversion = 0,99,0 ; [Ikemen-Only] Required Ikemen GO version
+
+[Camera]
+startx = 0 ; [MUGEN-Compat] Initial X position of camera
+starty = 0 ; [MUGEN-Compat] Initial Y position of camera
+boundleft = -500 ; [MUGEN-Compat] Minimum X position
+boundright = 500 ; [MUGEN-Compat] Maximum X position
+boundhigh = 0 ; [MUGEN-Compat] Highest Y camera position
+boundlow = 0 ; [MUGEN-Compat] Lowest Y camera position
+
+; [EXAMPLE] Custom wide stage bounds
+;boundleft = -1000
+;boundright = 1000
+
+[StageInfo]
+zoffset = 0 ; [MUGEN-Compat] Player ground level
+zoffsetlink = 1 ; [Ikemen-Only] Link floor to camera
+gravity = 1 ; [MUGEN-Compat] Vertical acceleration applied to players
+
+; [EXAMPLE] Enable vertical scrolling
+;topbound = -240 ; [MUGEN-Compat]
+;botbound = 0 ; [MUGEN-Compat]
+
+[Shadow]
+intensity = 128 ; [MUGEN-Compat] Darkness of shadow
+color = 000000 ; [MUGEN-Compat] Shadow color
+
+[Reflection]
+enabled = 1 ; [Ikemen-Only] Enable stage reflection effect
+
+; End of stage template

--- a/data/example.st
+++ b/data/example.st
@@ -1,0 +1,25 @@
+; State File Template for Ikemen GO
+; Each parameter references M.U.G.E.N documentation and notes compatibility.
+
+[Statedef 0]
+type = S ; [MUGEN-Compat] State type: S/A/C/L
+physics = S ; [MUGEN-Compat] Physics handling
+movetype = I ; [MUGEN-Compat] Move type (I=Idle)
+
+[State 0, ChangeAnim]
+type = ChangeAnim ; [MUGEN-Compat] Change animation at state start
+trigger1 = Time = 0 ; [MUGEN-Compat] Trigger on first frame
+value = 0 ; [MUGEN-Compat] Animation number
+
+[State 0, VelSet]
+type = VelSet ; [MUGEN-Compat] Set velocity
+trigger1 = 1 ; [MUGEN-Compat] Always active
+x = 0 ; [MUGEN-Compat] X velocity
+y = 0 ; [MUGEN-Compat] Y velocity
+
+; [EXAMPLE] Ikemen-only afterimage effect
+[State 0, AfterImage]
+type = AfterImage ; [Ikemen-Only] Create afterimage effect
+trigger1 = command = "qcf_x" ; [EXAMPLE] Use command from CMD
+palcolor = 256 ; [Ikemen-Only]
+palbright = 0,0,0 ; [Ikemen-Only]


### PR DESCRIPTION
## Summary
- add example stage, command, constants and state template files with line-by-line comments
- mark [MUGEN-Compat] versus [Ikemen-Only] parameters and link to M.U.G.E.N docs
- include [EXAMPLE] blocks for custom stage bounds and command inputs

## Testing
- `go test ./...` *(fails: Package gl was not found; X11/Xcursor/Xcursor.h: No such file or directory; Package alsa was not found; Package gtk+-3.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d0476cd4832fa9d1de19a9cd806f